### PR TITLE
Fixes

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -90,6 +90,18 @@ install_utilities() {
   fi
 }
 
+install_syntax() {
+  echo ''
+  echo 'Installing zsh-syntax-highlighting'
+  git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ~/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting
+}
+
+install_autosuggestions() {
+  echo ''
+  echo 'Installing zsh-autosuggestions'
+  git clone https://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions  
+}
+
 setup_zsh() {
   if [ "$SHELL" != "/bin/zsh" ]
   then
@@ -136,6 +148,8 @@ install_vundle
 install_tmux
 install_oh_my_zsh
 install_utilities
+install_autosuggestions
+install_syntax
 setup_zsh
 
 echo ''

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -61,7 +61,7 @@ DISABLE_AUTO_TITLE="true"
 DISABLE_AUTO_UPDATE="true"
 COMPLETION_WAITING_DOTS="true"
 
-plugins=(git osx ruby brew pod git-extras github jira wd zsh-syntax-highlighting zsh-autosuggestions history-substring-search)
+plugins=(git macos ruby brew pod git-extras github jira wd zsh-syntax-highlighting zsh-autosuggestions history-substring-search)
 
 source $ZSH/oh-my-zsh.sh
 


### PR DESCRIPTION
Fixes minor issues I ran into when installing these dotfiles on a new comp.

1. osx plugin has been renamed to macos
2. Two missing plugins: zsh-syntax-highlighting and zsh-autosuggestions